### PR TITLE
Add `requirements.txt` for dependencies installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
-for linux: ```pip install python-vlc ```
-
-for windows:
-‍‍```pip install python-vlc windows-curses```
-
+install dependencies:
+```python3 install -r requirements.txt```
 run:
 ```python3 radio.py```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+python-vlc
+windows-curses; sys_platform == 'win32'


### PR DESCRIPTION
PEP 508 defines a dependency specification for platform-specific packages, specifically the `sys_platform` marker, which can distinguish `windows-curses` package from other packages that will be installed.